### PR TITLE
메인 버튼 쉽게 누르도록 변경 & 기타 세팅

### DIFF
--- a/ggwadang.xcodeproj/project.pbxproj
+++ b/ggwadang.xcodeproj/project.pbxproj
@@ -407,7 +407,7 @@
 			};
 			buildConfigurationList = 4D7275F5284CEE5800F4DCC6 /* Build configuration list for PBXProject "ggwadang" */;
 			compatibilityVersion = "Xcode 13.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -615,6 +615,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ggwadang/Preview Content\"";
@@ -622,6 +623,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ggwadang/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "꽈당";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -633,7 +635,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teacoli.ggwadang;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -648,6 +650,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ggwadang/Preview Content\"";
@@ -655,6 +658,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ggwadang/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "꽈당";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -666,7 +670,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.teacoli.ggwadang;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ggwadang/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ggwadang/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ggwadang/Info.plist
+++ b/ggwadang/Info.plist
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ko_KR</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>CFBundleIcons</key>
+	<dict/>
+	<key>CFBundleIcons~ipad</key>
+	<dict/>
+</dict>
 </plist>

--- a/ggwadang/Views/Main/MainListView.swift
+++ b/ggwadang/Views/Main/MainListView.swift
@@ -15,10 +15,12 @@ struct MainListView: View {
     
     var body: some View {
         VStack {
-            HStack {
-                Text("오늘의 당 섭취").bold()
-                Spacer()
-                NavigationLink(destination: MainFullListView()) {
+            NavigationLink(destination: MainFullListView()) {
+                HStack {
+                    Text("오늘의 당 섭취")
+                        .bold()
+                        .foregroundColor(.black)
+                    Spacer()
                     Image(systemName: "chevron.right")
                         .font(.headline)
                 }


### PR DESCRIPTION
# What is this PR?
- 메인화면에서 상세화면을 더 쉽게 들어갈 수 있게 합니다.
    더보기 버튼("chevron.right") 누르기가 힘들어서 오늘의 당 섭취 자체를 클릭하면 navigation link가 되도록 했어요.
- App icon이 제대로 동작하도록 세팅합니다
    앱 아이콘이 제대로 적용이 안되어있어서 contents.json을 수정했어요.
- 앱 기본 언어를 한국어로 변경했습니다.
    영어지원이 안되는데 appstore에서 지원 언어가 english로 나와서 한국어로 변경했어요.

# Change
- MainLintView에서 chevron 이미지에만 Navigation Link가 걸려있었던 것을 "오늘의 당 섭취" 영역까지 포함해서 걸려있도록 변경
- contents.json 에 이미지 정보 추가
- 앱 기본 언어 변경
    1. info.plist에 한국어 추가
       <img width="482" alt="image" src="https://user-images.githubusercontent.com/57349859/192807481-1b3b6827-cb2e-4697-9cca-0021d1a95d2d.png">
    2. vscode에서 직접 언어 변경
       <img width="479" alt="image" src="https://user-images.githubusercontent.com/57349859/192807879-22e085cc-b4b7-4060-83d4-edb8b48b51cb.png">

# Screen Shot
 <img width="200" alt="image" src="https://user-images.githubusercontent.com/57349859/192810375-256dcbc0-d7ec-402b-a323-286609f4c18a.gif">

# Test
- [ ] 오늘의 당 섭취가 터치가 잘되는지 확인
- [ ] 앱스토어에 올라간 앱이 지원 언어가 한국어인지 확인